### PR TITLE
♻️ Tidy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-enjoyer"
+name = "function-selector-miner"
 version = "0.1.0"
 edition = "2021"
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -59,14 +59,14 @@ FORCE_INLINE V operator | (const V &a, const V &b)
     return V(_mm256_or_si256(a.v, b.v));
 }
 
-FORCE_INLINE V operator << (const V &a, uint64_t i)
+FORCE_INLINE V operator << (const V &a, int32_t i)
 {
-    return V(_mm256_sll_epi64(a.v, _mm_set1_epi64x(i)));
+    return V(_mm256_slli_epi64(a.v, i));
 }
 
-FORCE_INLINE V operator >> (const V &a, uint64_t i)
+FORCE_INLINE V operator >> (const V &a, int32_t i)
 {
-    return V(_mm256_srl_epi64(a.v, _mm_set1_epi64x(i)));
+    return V(_mm256_srli_epi64(a.v, i));
 }
 
 FORCE_INLINE V operator & (const V &a, const V &b)


### PR DESCRIPTION
Doesn't seem to have a difference in C++. despite intel intrinsics webpage saying that it is faster. 

Thus we should expect Rust to be same. Probably.

Unfortunately, Rust's `_mm256_srli_epi64` uses const generics (I don't know why lol), and Rust can't do const generics arithmetic. 